### PR TITLE
Support for real-time sync to Sunshine, through API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,24 @@
 # SunshineAppExport
 
-This is a [Playnite](https://github.com/JosefNemec/Playnite) addon that creates custom [Sunshine](https://github.com/LizardByte/Sunshine) apps from the currently selected games in Playnite.
+This is a [Playnite](https://github.com/JosefNemec/Playnite) addon that automatically syncs your installed games to [Sunshine](https://github.com/LizardByte/Sunshine), allowing you to stream them via [Moonlight](https://github.com/moonlight-stream).
 
-Once imported, you can launch them from [Moonlight](https://github.com/moonlight-stream). It even imports your Playnite box art.
+## Features
+- **Automatic Sync**: Syncs all installed games to Sunshine when Playnite starts.
+- **Manual Export**: Export specific selected games via the Extensions menu.
+- **Smart Removal**: Automatically removes games from Sunshine when they are uninstalled from Playnite (only affects games created by this extension).
+- **Cover Art**: Uploads Playnite box art to Sunshine.
 
-By default it will look for Sunshine's `apps.json` file at `C:\Program Files\Sunshine\config\apps.json`, but if you have a custom Sunshine install directory, the addon will ask you if you want to change where it looks for `apps.json`. 
+## Configuration
+1. Go to **Extensions** -> **Sunshine App Export** -> **Configure Sunshine Export**.
+2. Enter your Sunshine API URL (default: `https://localhost:47990`).
+3. Enter your Sunshine **Username** and **Password**.
+4. (Optional) Check **Ignore Certificate Errors** if you are using a self-signed certificate (common for default Sunshine installs).
+5. (Optional) Check **Sync on Playnite Startup** to enable automatic syncing (default: Off).
 
-<img src="dialog_screenshot.png" width="352">
+## Usage
+- **Manual**: Select games in Playnite, then select **Extensions** -> **Sunshine App Export** -> **Export selected games**.
+- **Automatic**: If enabled in settings, just launch Playnite. Your library will be synced in the background.
+
+## Requirements
+- Playnite
+- Sunshine (running and accessible)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This is a [Playnite](https://github.com/JosefNemec/Playnite) addon that automati
 
 ## Features
 - **Automatic Sync**: Syncs all installed games to Sunshine when Playnite starts.
+- **Real-Time Sync**: Automatically adds or removes games from Sunshine when they are installed or uninstalled in Playnite.
 - **Manual Export**: Export specific selected games via the Extensions menu.
 - **Smart Removal**: Automatically removes games from Sunshine when they are uninstalled from Playnite (only affects games created by this extension).
 - **Cover Art**: Uploads Playnite box art to Sunshine.
@@ -13,7 +14,8 @@ This is a [Playnite](https://github.com/JosefNemec/Playnite) addon that automati
 2. Enter your Sunshine API URL (default: `https://localhost:47990`).
 3. Enter your Sunshine **Username** and **Password**.
 4. (Optional) Check **Ignore Certificate Errors** if you are using a self-signed certificate (common for default Sunshine installs).
-5. (Optional) Check **Sync on Playnite Startup** to enable automatic syncing (default: Off).
+5. (Optional) Check **Sync on Playnite Startup** to sync your entire library completely every time Playnite starts (default: Off).
+6. (Optional) Check **Keep up to date (Real-time sync)** to automatically add/remove games in Sunshine as you install/uninstall them in Playnite (default: Off).
 
 ## Usage
 - **Manual**: Select games in Playnite, then select **Extensions** -> **Sunshine App Export** -> **Export selected games**.

--- a/SunshineAppExport.psm1
+++ b/SunshineAppExport.psm1
@@ -176,6 +176,7 @@ function Invoke-SunshineRequest {
         if ($Body) {
             $json = $Body | ConvertTo-Json -Depth 10
             $content = New-Object System.Net.Http.StringContent($json, [System.Text.Encoding]::UTF8, "application/json")
+            $__logger.Info("Sunshine DEBUG: Request Body: $json")
         }
 
         $__logger.Info("Sunshine DEBUG: Invoking $Method request to $uri")
@@ -236,22 +237,45 @@ function Remove-SunshineApp {
 }
 
 function OnApplicationStarted {
-    $config = Get-PluginConfig
-    if (-not $config.SyncOnStartup) {
-        return
-    }
+    # Only set startup time - actual sync is deferred to OnLibraryUpdated
+    # This avoids race conditions with lazy-loading libraries like Epic Games Store
+    $script:AppStartTime = Get-Date
+    $script:HasRunStartupSync = $false
+    $__logger.Info("Sunshine Export: Application started, sync will run after library update.")
+}
 
-    $installedGames = $PlayniteApi.Database.Games | Where-Object { $_.IsInstalled }
-    # Convert to List for Sync-Games
-    $gamesList = New-Object System.Collections.Generic.List[Playnite.SDK.Models.Game]
-    if ($installedGames) {
-        foreach ($game in $installedGames) {
-            $gamesList.Add($game)
+function OnLibraryUpdated {
+    $config = Get-PluginConfig
+    if ($config.SyncOnStartup) {
+        # Only run once during startup window, use flag to prevent duplicates
+        if ($script:HasRunStartupSync) {
+            $__logger.Info("Sunshine Export: Startup sync already completed, skipping.")
+            return
+        }
+        
+        # Allow syncs triggered by library updates for the first 2 minutes to catch lazy-loaded libraries (like Epic)
+        if ($script:AppStartTime -and (Get-Date) -lt $script:AppStartTime.AddMinutes(2)) {
+            # Mark as running immediately to prevent concurrent syncs
+            $script:HasRunStartupSync = $true
+            
+            $__logger.Info("Sunshine Export: Triggering startup sync due to library update...")
+            
+            # Wait 10 seconds to ensure ALL library plugins have fully propagated IsInstalled states
+            # Epic Games Store is particularly slow to report installed status
+            Start-Sleep -Seconds 10
+
+            $installedGames = $PlayniteApi.Database.Games | Where-Object { $_.IsInstalled }
+            $gamesList = New-Object System.Collections.Generic.List[Playnite.SDK.Models.Game]
+            if ($installedGames) {
+                foreach ($game in $installedGames) {
+                    $gamesList.Add($game)
+                }
+            }
+            
+            $count = Sync-Games -GamesToSync $gamesList -RemoveMissing $true
+            $__logger.Info("Sunshine Export: Synced $count games after library update.")
         }
     }
-    
-    $count = Sync-Games -GamesToSync $gamesList -RemoveMissing $true
-    $__logger.Info("Sunshine Export: Synced $count games on startup.")
 }
 
 function OnGameInstalled {
@@ -371,16 +395,77 @@ function GetGameIdFromCmd([string]$cmd) {
     }
 }
 
+function PrepareGameCover {
+    param(
+        [Playnite.SDK.Models.Game]$Game,
+        [string]$TargetPath
+    )
+    
+    # Ensure target directory exists
+    $targetDir = [System.IO.Path]::GetDirectoryName($TargetPath)
+    if (!(Test-Path $targetDir -PathType Container)) {
+        New-Item -ItemType Directory -Path $targetDir -Force | Out-Null
+    }
+    
+    # Create blank file if it doesn't exist
+    if (!(Test-Path $TargetPath -PathType Leaf)) {
+        New-Item -ItemType File -Path $TargetPath -Force | Out-Null
+    }
+
+    if ($null -ne $Game.CoverImage) {
+        $sourceCover = $PlayniteApi.Database.GetFullFilePath($Game.CoverImage)
+        if (($Game.CoverImage -notmatch "^http") -and (Test-Path $sourceCover -PathType Leaf)) {
+            if ([System.IO.Path]::GetExtension($Game.CoverImage) -eq ".png") {
+                Copy-Item $sourceCover $TargetPath -Force
+            }
+            else {
+                # Convert cover image to compatible PNG image format
+                try {
+                    $bitmap = New-Object System.Windows.Media.Imaging.BitmapImage
+                    $bitmap.BeginInit()
+                    $bitmap.UriSource = New-Object System.Uri($sourceCover, [System.UriKind]::Absolute)
+                    $bitmap.CacheOption = [System.Windows.Media.Imaging.BitmapCacheOption]::OnLoad
+                    $bitmap.EndInit()
+                
+                    $encoder = New-Object System.Windows.Media.Imaging.PngBitmapEncoder
+                    $frame = [System.Windows.Media.Imaging.BitmapFrame]::Create($bitmap)
+                    $encoder.Frames.Add($frame)
+                
+                    $fileStream = New-Object System.IO.FileStream($TargetPath, [System.IO.FileMode]::Create)
+                    $encoder.Save($fileStream)
+                    $fileStream.Close()
+                }
+                catch {
+                    if ($null -ne $bitmap) { $bitmap = $null }
+                    if ($null -ne $fileStream) { $fileStream.Close() }
+                    $errorMessage = $_.Exception.Message
+                    $__logger.Info("Error converting cover image of `"$($Game.Name)`". Error: $errorMessage")
+                }
+            }
+        }
+    }
+    
+    # Verify cover image exists and is valid (not 0 bytes)
+    $finalCoverPath = $TargetPath
+    try {
+        $coverItem = Get-Item $TargetPath -ErrorAction Stop
+        if ($coverItem.Length -eq 0) {
+            $finalCoverPath = ""
+        }
+    }
+    catch {
+        $finalCoverPath = ""
+    }
+    
+    return $finalCoverPath
+}
+
 function Sync-Games {
     param(
         [System.Collections.Generic.List[Playnite.SDK.Models.Game]]$GamesToSync,
         [bool]$RemoveMissing = $false
     )
 
-    # Load assemblies
-    Add-Type -AssemblyName System.Drawing
-    $imageFormat = "System.Drawing.Imaging.ImageFormat" -as [type]
-    
     # Set paths
     $playniteExecutablePath = Join-Path -Path $PlayniteApi.Paths.ApplicationPath -ChildPath "Playnite.DesktopApp.exe"
     $appAssetsPath = Join-Path -Path $env:LocalAppData -ChildPath "Sunshine Playnite App Export\Apps"
@@ -399,87 +484,200 @@ function Sync-Games {
         return 0
     }
 
-    # Create a hashset of Game IDs to sync for O(1) lookup
-    $gamesToSyncIds = New-Object System.Collections.Generic.HashSet[string]
-    foreach ($game in $GamesToSync) {
-        $gamesToSyncIds.Add($game.Id.ToString()) | Out-Null
+    # --- Phase 1: Deduplicate Existing Apps ---
+    # We must do this before syncing because deleting items shifts indices, which invalidates logic if done inline.
+    $duplicatesFound = $false
+    $idsToIndexMap = @{} # Key: GameID, Value: List of Indices
+
+    # 1. Map all existing apps
+    for ($i = 0; $i -lt $sunshineApps.Count; $i++) {
+        $app = $sunshineApps[$i]
+        if ($app.detached -and $app.detached.Length -gt 0) {
+            $existingGameId = GetGameIdFromCmd($app.detached[0])
+            if (![string]::IsNullOrEmpty($existingGameId)) {
+                if (-not $idsToIndexMap.ContainsKey($existingGameId)) {
+                    $idsToIndexMap[$existingGameId] = New-Object System.Collections.Generic.List[int]
+                }
+                $idsToIndexMap[$existingGameId].Add($i)
+            }
+        }
     }
 
-    # 1. Add/Update Games
+    # 2. Convert to flat list of indices to remove (Keep the first/lowest index, remove others)
+    $indicesToRemove = New-Object System.Collections.Generic.List[int]
+    foreach ($key in $idsToIndexMap.Keys) {
+        $indices = $idsToIndexMap[$key]
+        if ($indices.Count -gt 1) {
+            # Keep index 0 (the first one found, usually lowest), remove the rest
+            for ($k = 1; $k -lt $indices.Count; $k++) {
+                $indicesToRemove.Add($indices[$k])
+            }
+        }
+    }
+
+    # 3. Remove duplicates (Backwards to preserve indices)
+    if ($indicesToRemove.Count -gt 0) {
+        $duplicatesFound = $true
+        $indicesToRemove.Sort() 
+        $indicesToRemove.Reverse() # Remove from end to start
+        
+        foreach ($idx in $indicesToRemove) {
+            try {
+                Remove-SunshineApp -Index $idx
+                $__logger.Info("Sunshine Export: Removed duplicate app at index $idx")
+            }
+            catch {
+                $__logger.Error("Failed to remove duplicate app at index $idx : $_")
+            }
+        }
+    }
+
+    # 4. Re-fetch apps if we modified anything
+    if ($duplicatesFound) {
+        Start-Sleep -Milliseconds 500 # Brief pause for API to settle
+        try {
+            $sunshineAppsResponse = Get-SunshineApps
+            $sunshineApps = $sunshineAppsResponse.apps
+        }
+        catch {
+            $__logger.Error("Failed to re-fetch apps after deduplication.")
+            return 0
+        }
+    }
+    # ------------------------------------------
+
+    # Create a hashset of Game IDs to sync for O(1) lookup
+    $gamesToSyncIds = New-Object System.Collections.Generic.HashSet[string]
+    $gameNames = @()
     foreach ($game in $GamesToSync) {
+        $gamesToSyncIds.Add($game.Id.ToString()) | Out-Null
+        $gameNames += $game.Name
+    }
+    $__logger.Info("Sunshine Export: Found installed games: $($gameNames -join ', ')")
+
+    # Build a map of existing Game IDs to their Sunshine index for fast lookup
+    $existingGameIdToIndex = @{}
+    for ($i = 0; $i -lt $sunshineApps.Count; $i++) {
+        $app = $sunshineApps[$i]
+        if ($app.detached -and $app.detached.Length -gt 0) {
+            $existingGameId = GetGameIdFromCmd($app.detached[0])
+            if (![string]::IsNullOrEmpty($existingGameId)) {
+                # Only keep the first occurrence (duplicates handled in Phase 1)
+                if (-not $existingGameIdToIndex.ContainsKey($existingGameId)) {
+                    $existingGameIdToIndex[$existingGameId] = $i
+                }
+            }
+        }
+    }
+
+    # Separate games into NEW (not in Sunshine) and EXISTING (already in Sunshine)
+    $newGames = @()
+    $existingGames = @()
+    foreach ($game in $GamesToSync) {
+        if ($existingGameIdToIndex.ContainsKey($game.Id.ToString())) {
+            $existingGames += $game
+        }
+        else {
+            $newGames += $game
+        }
+    }
+    
+    $__logger.Info("Sunshine Export: $($newGames.Count) new games, $($existingGames.Count) existing games to sync.")
+
+    # --- Phase 2A: Add NEW games first ---
+    # This must be done before updates because adding apps can shift indices
+    foreach ($game in $newGames) {
         $gameLaunchCmd = "`"$playniteExecutablePath`" --start $($game.Id)"
-
-        # Set cover path and create blank file
+        
+        # Prepare cover image
         $sunshineGameCoverPath = [System.IO.Path]::Combine($appAssetsPath, $game.Id, "box-art.png")
-        if (!(Test-Path $sunshineGameCoverPath -PathType Container)) {
-            New-Item -ItemType File -Path $sunshineGameCoverPath -Force | Out-Null
-        }
-
-        if ($null -ne $game.CoverImage) {
-            $sourceCover = $PlayniteApi.Database.GetFullFilePath($game.CoverImage)
-            if (($game.CoverImage -notmatch "^http") -and (Test-Path $sourceCover -PathType Leaf)) {
-                if ([System.IO.Path]::GetExtension($game.CoverImage) -eq ".png") {
-                    Copy-Item $sourceCover $sunshineGameCoverPath -Force
-                }
-                else {
-                    # Convert cover image to compatible PNG image format
-                    try {
-                        $bitmap = New-Object System.Windows.Media.Imaging.BitmapImage
-                        $bitmap.BeginInit()
-                        $bitmap.UriSource = New-Object System.Uri($sourceCover, [System.UriKind]::Absolute)
-                        $bitmap.CacheOption = [System.Windows.Media.Imaging.BitmapCacheOption]::OnLoad
-                        $bitmap.EndInit()
-                    
-                        $encoder = New-Object System.Windows.Media.Imaging.PngBitmapEncoder
-                        $frame = [System.Windows.Media.Imaging.BitmapFrame]::Create($bitmap)
-                        $encoder.Frames.Add($frame)
-                    
-                        $fileStream = New-Object System.IO.FileStream($sunshineGameCoverPath, [System.IO.FileMode]::Create)
-                        $encoder.Save($fileStream)
-                        $fileStream.Close()
-                    }
-                    catch {
-                        if ($null -ne $bitmap) { $bitmap = $null }
-                        if ($null -ne $fileStream) { $fileStream.Close() }
-                        $errorMessage = $_.Exception.Message
-                        $__logger.Info("Error converting cover image of `"$($game.Name)`". Error: $errorMessage")
-                    }
-                }
-            }
-        }
-
-        # Check if app already exists in Sunshine
-        $existingAppIndex = -1
-        for ($i = 0; $i -lt $sunshineApps.Count; $i++) {
-            $app = $sunshineApps[$i]
-            if ($app.detached -and $app.detached.Length -gt 0) {
-                $existingGameId = GetGameIdFromCmd($app.detached[0])
-                if ($existingGameId -eq $game.Id.ToString()) {
-                    $existingAppIndex = $i
-                    break
-                }
-            }
-        }
-
+        $finalCoverPath = PrepareGameCover -Game $game -TargetPath $sunshineGameCoverPath
+        
         $newApp = @{
             name         = $game.Name
             detached     = @($gameLaunchCmd)
-            "image-path" = $sunshineGameCoverPath
-            index        = $existingAppIndex
+            "image-path" = $finalCoverPath
+            index        = -1  # New app
         }
 
         try {
             Add-SunshineApp -App $newApp
             $shortcutsCreatedCount++
+            $__logger.Info("Sunshine Export: Added new game: $($game.Name)")
         }
         catch {
-            $__logger.Error("Failed to add/update app for game $($game.Name): $_")
+            $__logger.Error("Failed to add new app for game $($game.Name): $_")
+        }
+    }
+
+    # --- Phase 2B: Re-fetch apps after adding new ones to get fresh indices ---
+    if ($newGames.Count -gt 0 -and $existingGames.Count -gt 0) {
+        Start-Sleep -Milliseconds 300  # Brief pause for API to settle
+        try {
+            $sunshineAppsResponse = Get-SunshineApps
+            $sunshineApps = $sunshineAppsResponse.apps
+            
+            # Rebuild the index map with fresh data
+            $existingGameIdToIndex = @{}
+            for ($i = 0; $i -lt $sunshineApps.Count; $i++) {
+                $app = $sunshineApps[$i]
+                if ($app.detached -and $app.detached.Length -gt 0) {
+                    $existingGameId = GetGameIdFromCmd($app.detached[0])
+                    if (![string]::IsNullOrEmpty($existingGameId)) {
+                        if (-not $existingGameIdToIndex.ContainsKey($existingGameId)) {
+                            $existingGameIdToIndex[$existingGameId] = $i
+                        }
+                    }
+                }
+            }
+        }
+        catch {
+            $__logger.Error("Failed to re-fetch apps after adding new games: $_")
+            # Continue with stale data - updates may be slightly off but better than failing
+        }
+    }
+
+    # --- Phase 2C: Update EXISTING games with fresh indices ---
+    foreach ($game in $existingGames) {
+        $gameLaunchCmd = "`"$playniteExecutablePath`" --start $($game.Id)"
+        
+        # Prepare cover image
+        $sunshineGameCoverPath = [System.IO.Path]::Combine($appAssetsPath, $game.Id, "box-art.png")
+        $finalCoverPath = PrepareGameCover -Game $game -TargetPath $sunshineGameCoverPath
+        
+        # Get the current index from our map (should exist since we categorized it as existing)
+        $currentIndex = $existingGameIdToIndex[$game.Id.ToString()]
+        
+        $newApp = @{
+            name         = $game.Name
+            detached     = @($gameLaunchCmd)
+            "image-path" = $finalCoverPath
+            index        = $currentIndex
+        }
+
+        try {
+            Add-SunshineApp -App $newApp
+            $shortcutsCreatedCount++
+            $__logger.Info("Sunshine DEBUG: Updated game at index $currentIndex : $($game.Name)")
+        }
+        catch {
+            $__logger.Error("Failed to update app for game $($game.Name): $_")
         }
     }
 
     # 2. Remove Missing Games (if requested)
     if ($RemoveMissing) {
-       
+        # We need to iterate backwards because removing items changes indices?
+        # Wait, Sunshine API uses index. If we remove item at index 0, does item at index 1 become 0?
+        # Most likely yes. So we should verify this or iterate backwards.
+        # However, the API documentation says: "Delete an application." DELETE /api/apps/{index}
+        # It's safer to iterate backwards.
+        
+        # Also, we need to be careful: if we remove an app, the indices of subsequent apps shift.
+        # So we should probably re-fetch the list or be very careful.
+        # Re-fetching is safer but slower.
+        # Iterating backwards is usually safe for removal by index.
+        
         for ($i = $sunshineApps.Count - 1; $i -ge 0; $i--) {
             $app = $sunshineApps[$i]
             if ($app.detached -and $app.detached.Length -gt 0) {

--- a/SunshineAppExport.psm1
+++ b/SunshineAppExport.psm1
@@ -30,6 +30,7 @@ function Get-PluginConfig {
         SunshinePass            = ""
         IgnoreCertificateErrors = $true
         SyncOnStartup           = $false
+        KeepUpToDate            = $false
     }
 }
 
@@ -69,6 +70,7 @@ function Show-ConfigurationDialog {
         
         <CheckBox x:Name="IgnoreCertErrors" Content="Ignore Certificate Errors" Margin="0,0,0,15"/>
         <CheckBox x:Name="SyncOnStartup" Content="Sync on Playnite Startup" Margin="0,0,0,15"/>
+        <CheckBox x:Name="KeepUpToDate" Content="Keep up to date (Real-time sync)" Margin="0,0,0,15"/>
         
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
             <Button x:Name="SaveButton" Content="Save" Width="75" Margin="0,0,10,0"/>
@@ -87,6 +89,7 @@ function Show-ConfigurationDialog {
     $window.Content.FindName("SunshinePass").Password = $config.SunshinePass
     $window.Content.FindName("IgnoreCertErrors").IsChecked = $config.IgnoreCertificateErrors
     $window.Content.FindName("SyncOnStartup").IsChecked = $config.SyncOnStartup
+    $window.Content.FindName("KeepUpToDate").IsChecked = $config.KeepUpToDate
 
     # Event Handlers
     $window.Content.FindName("SaveButton").Add_Click({
@@ -96,6 +99,7 @@ function Show-ConfigurationDialog {
                 SunshinePass            = $window.Content.FindName("SunshinePass").Password
                 IgnoreCertificateErrors = $window.Content.FindName("IgnoreCertErrors").IsChecked
                 SyncOnStartup           = $window.Content.FindName("SyncOnStartup").IsChecked
+                KeepUpToDate            = $window.Content.FindName("KeepUpToDate").IsChecked
             }
             Set-PluginConfig -Config $newConfig
             $window.Close()
@@ -110,6 +114,30 @@ function Show-ConfigurationDialog {
     $window.ShowDialog()
 }
 
+# Helper type for safe SSL validation without using PowerShell ScriptBlocks
+try {
+    $code = @"
+    using System;
+    using System.Net.Http;
+    using System.Security.Cryptography.X509Certificates;
+    using System.Net.Security;
+
+    namespace SunshineExport {
+        public class CertificateBypass {
+            public static Func<HttpRequestMessage, X509Certificate2, X509Chain, SslPolicyErrors, bool> Callback = 
+                (msg, cert, chain, sslErrors) => true;
+        }
+    }
+"@
+    if (-not ([System.Management.Automation.PSTypeName]'SunshineExport.CertificateBypass').Type) {
+        Add-Type -TypeDefinition $code -Language CSharp -ReferencedAssemblies System.Net.Http
+    }
+}
+catch {
+    # Ignored, type might already exist or assembly issue
+    $__logger.Error("Failed to add CertificateBypass type: $_")
+}
+
 function Invoke-SunshineRequest {
     param(
         [string]$Method,
@@ -121,34 +149,75 @@ function Invoke-SunshineRequest {
     $baseUri = $config.SunshineUrl.TrimEnd('/')
     $uri = "$baseUri$Endpoint"
 
-    $headers = @{}
-    if (![string]::IsNullOrEmpty($config.SunshineUser) -or ![string]::IsNullOrEmpty($config.SunshinePass)) {
-        $auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $config.SunshineUser, $config.SunshinePass)))
-        $headers.Add("Authorization", "Basic $auth")
-    }
-
-    $params = @{
-        Uri         = $uri
-        Method      = $Method
-        Headers     = $headers
-        ContentType = "application/json"
-    }
-
-    if ($Body) {
-        $params.Body = $Body | ConvertTo-Json -Depth 10
-    }
-
+    $handler = New-Object System.Net.Http.HttpClientHandler
     if ($config.IgnoreCertificateErrors) {
-        $params.SkipCertificateCheck = $true
+        try {
+            # Use the compiled C# delegate to avoid Runspace issues
+            $handler.ServerCertificateCustomValidationCallback = [SunshineExport.CertificateBypass]::Callback
+        }
+        catch {
+            $__logger.Error("Failed to set SSL bypass callback: $_")
+        }
     }
 
+    $client = New-Object System.Net.Http.HttpClient($handler)
     try {
-        $response = Invoke-RestMethod @params
-        return $response
+        $client.BaseAddress = New-Object System.Uri($baseUri)
+        
+        # Auth
+        if (![string]::IsNullOrEmpty($config.SunshineUser) -or ![string]::IsNullOrEmpty($config.SunshinePass)) {
+            $authBytes = [System.Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $config.SunshineUser, $config.SunshinePass))
+            $authString = [System.Convert]::ToBase64String($authBytes)
+            $client.DefaultRequestHeaders.Authorization = New-Object System.Net.Http.Headers.AuthenticationHeaderValue("Basic", $authString)
+        }
+
+        # Content
+        $content = $null
+        if ($Body) {
+            $json = $Body | ConvertTo-Json -Depth 10
+            $content = New-Object System.Net.Http.StringContent($json, [System.Text.Encoding]::UTF8, "application/json")
+        }
+
+        $__logger.Info("Sunshine DEBUG: Invoking $Method request to $uri")
+
+        # Execute
+        if ($Method -eq "GET") {
+            $task = $client.GetAsync($Endpoint)
+        }
+        elseif ($Method -eq "POST") {
+            $task = $client.PostAsync($Endpoint, $content)
+        }
+        elseif ($Method -eq "DELETE") {
+            $task = $client.DeleteAsync($Endpoint)
+        }
+        
+        $task.Wait()
+        $result = $task.Result
+        
+        $responseBodyTask = $result.Content.ReadAsStringAsync()
+        $responseBodyTask.Wait()
+        $responseBody = $responseBodyTask.Result
+
+        if (-not $result.IsSuccessStatusCode) {
+            $__logger.Error("Sunshine DEBUG: API Error ($($result.StatusCode)): $responseBody")
+            throw "Sunshine API returned $($result.StatusCode): $responseBody"
+        }
+
+        $__logger.Info("Sunshine DEBUG: Request successful.")
+        
+        try {
+            if ([string]::IsNullOrWhiteSpace($responseBody)) {
+                return $null
+            }
+            return $responseBody | ConvertFrom-Json
+        }
+        catch {
+            return $responseBody
+        }
     }
-    catch {
-        $__logger.Error("Sunshine API Error: $_")
-        throw $_
+    finally {
+        $client.Dispose()
+        $handler.Dispose()
     }
 }
 
@@ -175,10 +244,93 @@ function OnApplicationStarted {
     $installedGames = $PlayniteApi.Database.Games | Where-Object { $_.IsInstalled }
     # Convert to List for Sync-Games
     $gamesList = New-Object System.Collections.Generic.List[Playnite.SDK.Models.Game]
-    $gamesList.AddRange($installedGames)
+    if ($installedGames) {
+        foreach ($game in $installedGames) {
+            $gamesList.Add($game)
+        }
+    }
     
     $count = Sync-Games -GamesToSync $gamesList -RemoveMissing $true
     $__logger.Info("Sunshine Export: Synced $count games on startup.")
+}
+
+function OnGameInstalled {
+    param($Event)
+    
+    $Game = $Event
+    # Check if input is the EventArgs wrapper (OnGameInstalledEventArgs)
+    if ($Event.PSObject.Properties['Game']) {
+        $Game = $Event.Game
+    }
+
+    $config = Get-PluginConfig
+    if ($config.KeepUpToDate) {
+        $gamesList = New-Object System.Collections.Generic.List[Playnite.SDK.Models.Game]
+        try {
+            $gamesList.Add($Game)
+            Sync-Games -GamesToSync $gamesList -RemoveMissing $false
+            $__logger.Info("Sunshine Export: Auto-synced installed game: $($Game.Name)")
+        }
+        catch {
+            $__logger.Error("Sunshine Export: Failed to process installed game. Input Type: $($Event.GetType().FullName). Error: $_")
+        }
+    }
+}
+
+function OnGameUninstalled {
+    param($Event)
+    
+    $Game = $Event
+    # Check if input is the EventArgs wrapper (OnGameUninstalledEventArgs)
+    if ($Event.PSObject.Properties['Game']) {
+        $Game = $Event.Game
+    }
+
+    $config = Get-PluginConfig
+    if ($config.KeepUpToDate) {
+        try {
+            $sunshineAppsResponse = Get-SunshineApps
+            $sunshineApps = $sunshineAppsResponse.apps
+        }
+        catch {
+            $__logger.Error("Sunshine Export: Failed to fetch apps for uninstall: $_")
+            return
+        }
+
+        # Check if we have apps to check
+        if ($null -eq $sunshineApps) {
+            $__logger.Info("Sunshine Export: No apps found in Sunshine to check for removal.")
+            return
+        }
+
+        $indexToRemove = -1
+        for ($i = 0; $i -lt $sunshineApps.Count; $i++) {
+            $app = $sunshineApps[$i]
+            
+            # Safely check for detached property and its content
+            if ($null -ne $app -and $null -ne $app.detached -and $app.detached.Count -gt 0) {
+                # GetGameIdFromCmd is defined later in the file, but visible in module scope
+                $detachedCmd = $app.detached[0]
+                if ($null -ne $detachedCmd) {
+                    $existingGameId = GetGameIdFromCmd($detachedCmd)
+                    if ($existingGameId -eq $Game.Id.ToString()) {
+                        $indexToRemove = $i
+                        break
+                    }
+                }
+            }
+        }
+        
+        if ($indexToRemove -ge 0) {
+            try {
+                Remove-SunshineApp -Index $indexToRemove
+                $__logger.Info("Sunshine Export: Auto-removed uninstalled game: $($Game.Name)")
+            }
+            catch {
+                $__logger.Error("Sunshine Export: Failed to remove uninstalled game: $_")
+            }
+        }
+    }
 }
 
 function SunshineExport {
@@ -186,8 +338,27 @@ function SunshineExport {
         $scriptMainMenuItemActionArgs
     )
 
-    $shortcutsCreatedCount = Sync-Games -GamesToSync $PlayniteApi.MainView.SelectedGames -RemoveMissing $false
-    $PlayniteApi.Dialogs.ShowMessage("Exported $shortcutsCreatedCount games to Sunshine.", "Sunshine Export")
+    $selectedInstalledGames = $PlayniteApi.MainView.SelectedGames | Where-Object { $_.IsInstalled }
+    
+    $gamesList = New-Object System.Collections.Generic.List[Playnite.SDK.Models.Game]
+    if ($selectedInstalledGames) {
+        foreach ($game in $selectedInstalledGames) {
+            $gamesList.Add($game)
+        }
+    }
+
+    $shortcutsCreatedCount = Sync-Games -GamesToSync $gamesList -RemoveMissing $false
+    
+    $totalSelected = 0
+    if ($PlayniteApi.MainView.SelectedGames) { $totalSelected = $PlayniteApi.MainView.SelectedGames.Count }
+
+    $message = "Exported $shortcutsCreatedCount games to Sunshine."
+    if ($totalSelected -gt $gamesList.Count) {
+        $skipped = $totalSelected - $gamesList.Count
+        $message += "`n($skipped non-installed games skipped)"
+    }
+
+    $PlayniteApi.Dialogs.ShowMessage($message, "Sunshine Export")
 }
 
 function GetGameIdFromCmd([string]$cmd) {
@@ -308,17 +479,7 @@ function Sync-Games {
 
     # 2. Remove Missing Games (if requested)
     if ($RemoveMissing) {
-        # We need to iterate backwards because removing items changes indices?
-        # Wait, Sunshine API uses index. If we remove item at index 0, does item at index 1 become 0?
-        # Most likely yes. So we should verify this or iterate backwards.
-        # However, the API documentation says: "Delete an application." DELETE /api/apps/{index}
-        # It's safer to iterate backwards.
-        
-        # Also, we need to be careful: if we remove an app, the indices of subsequent apps shift.
-        # So we should probably re-fetch the list or be very careful.
-        # Re-fetching is safer but slower.
-        # Iterating backwards is usually safe for removal by index.
-        
+       
         for ($i = $sunshineApps.Count - 1; $i -ge 0; $i--) {
             $app = $sunshineApps[$i]
             if ($app.detached -and $app.detached.Length -gt 0) {
@@ -331,7 +492,7 @@ function Sync-Games {
                             $__logger.Info("Removed Sunshine app for game ID: $existingGameId")
                         }
                         catch {
-                            $__logger.Error("Failed to remove Sunshine app at index $i: $_")
+                            $__logger.Error("Failed to remove Sunshine app at index ${i}: $_")
                         }
                     }
                 }

--- a/SunshineAppExport.psm1
+++ b/SunshineAppExport.psm1
@@ -10,72 +10,70 @@ function GetMainMenuItems {
     $menuItem1.Description = "Export selected games"
     $menuItem1.FunctionName = "SunshineExport"
     $menuItem1.MenuSection = "@Sunshine App Export"
+
+    $menuItem2 = New-Object Playnite.SDK.Plugins.ScriptMainMenuItem
+    $menuItem2.Description = "Configure Sunshine Export"
+    $menuItem2.FunctionName = "Show-ConfigurationDialog"
+    $menuItem2.MenuSection = "@Sunshine App Export"
     
-    return $menuItem1
+    return $menuItem1, $menuItem2
 }
 
-function SunshineExport {
-    param(
-        $scriptMainMenuItemActionArgs
-    )
+function Get-PluginConfig {
+    $configPath = Join-Path -Path (Split-Path $script:MyInvocation.MyCommand.Path) -ChildPath "config.json"
+    if (Test-Path $configPath) {
+        return Get-Content $configPath | ConvertFrom-Json
+    }
+    return @{
+        SunshineUrl             = "https://localhost:47990"
+        SunshineUser            = ""
+        SunshinePass            = ""
+        IgnoreCertificateErrors = $true
+        SyncOnStartup           = $false
+    }
+}
+
+function Set-PluginConfig {
+    param($Config)
+    $configPath = Join-Path -Path (Split-Path $script:MyInvocation.MyCommand.Path) -ChildPath "config.json"
+    $Config | ConvertTo-Json | Set-Content $configPath
+}
+
+function Show-ConfigurationDialog {
+    param($showConfigArgs)
+
+    $config = Get-PluginConfig
 
     $windowCreationOptions = New-Object Playnite.SDK.WindowCreationOptions
     $windowCreationOptions.ShowMinimizeButton = $false
     $windowCreationOptions.ShowMaximizeButton = $false
     
     $window = $PlayniteApi.Dialogs.CreateWindow($windowCreationOptions)
-    $window.Title = "Sunshine App Export"
+    $window.Title = "Sunshine Configuration"
     $window.SizeToContent = "WidthAndHeight"
     $window.ResizeMode = "NoResize"
     
-    # Set content of a window. Can be loaded from xaml, loaded from UserControl or created from code behind
     [xml]$xaml = @"
 <UserControl
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-
-    <UserControl.Resources>
-        <Style TargetType="TextBlock" BasedOn="{StaticResource BaseTextBlockStyle}" />
-    </UserControl.Resources>
-
-    <StackPanel Margin="16,16,16,16">
-        <TextBlock Text="Enter your Sunshine apps.json path" 
-        Margin="0,0,0,8" 
-        VerticalAlignment="Center"/>
-
-        <Grid>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-
-            <TextBox x:Name="SunshinePath"
-            Grid.Column="0"
-            Margin="0,0,8,0"
-            Width="320"
-            Height="36"
-            HorizontalAlignment="Stretch"
-            VerticalAlignment="Top"/>
-
-            <Button x:Name="BrowseButton"
-            Grid.Column="1"
-            Width="72"
-            Height="36"
-            HorizontalAlignment="Right"
-            Content="Browse"/>
-        </Grid>
-
-        <TextBlock x:Name="FinishedMessage" 
-        Margin="0,0,0,24" 
-        VerticalAlignment="Center"
-        Visibility="Collapsed"/>
-
-        <Button x:Name="OKButton"
-        IsDefault="true"
-        Height= "36"
-        Margin="0,5,0,0"
-        HorizontalAlignment="Center"
-        Content="Export Games"/>
+    <StackPanel Margin="20">
+        <TextBlock Text="Sunshine URL:" Margin="0,0,0,5"/>
+        <TextBox x:Name="SunshineUrl" Width="300" Margin="0,0,0,15"/>
+        
+        <TextBlock Text="Username:" Margin="0,0,0,5"/>
+        <TextBox x:Name="SunshineUser" Width="300" Margin="0,0,0,15"/>
+        
+        <TextBlock Text="Password:" Margin="0,0,0,5"/>
+        <PasswordBox x:Name="SunshinePass" Width="300" Margin="0,0,0,15"/>
+        
+        <CheckBox x:Name="IgnoreCertErrors" Content="Ignore Certificate Errors" Margin="0,0,0,15"/>
+        <CheckBox x:Name="SyncOnStartup" Content="Sync on Playnite Startup" Margin="0,0,0,15"/>
+        
+        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="SaveButton" Content="Save" Width="75" Margin="0,0,10,0"/>
+            <Button x:Name="CancelButton" Content="Cancel" Width="75"/>
+        </StackPanel>
     </StackPanel>
 </UserControl>
 "@
@@ -83,49 +81,113 @@ function SunshineExport {
     $reader = [System.Xml.XmlNodeReader]::new($xaml)
     $window.Content = [Windows.Markup.XamlReader]::Load($reader)
 
-    $appsPath = "$Env:ProgramW6432\Sunshine\config\apps.json"
+    # Populate fields
+    $window.Content.FindName("SunshineUrl").Text = $config.SunshineUrl
+    $window.Content.FindName("SunshineUser").Text = $config.SunshineUser
+    $window.Content.FindName("SunshinePass").Password = $config.SunshinePass
+    $window.Content.FindName("IgnoreCertErrors").IsChecked = $config.IgnoreCertificateErrors
+    $window.Content.FindName("SyncOnStartup").IsChecked = $config.SyncOnStartup
 
-    $inputField = $window.Content.FindName("SunshinePath")
-    $inputField.Text = $appsPath   
-    
-    # Attach a click event handler to the Browse button
-    $browseButton = $window.Content.FindName("BrowseButton")
-    $browseButton.Add_Click({
-            $openFileDialog = New-Object System.Windows.Forms.OpenFileDialog
-            $openFileDialog.InitialDirectory = Split-Path $inputField.Text -Parent
-            $openFileDialog.Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*"
-            $openFileDialog.Title = "Open apps.json"
-    
-            if ($openFileDialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
-                $inputField.Text = $openFileDialog.FileName
+    # Event Handlers
+    $window.Content.FindName("SaveButton").Add_Click({
+            $newConfig = @{
+                SunshineUrl             = $window.Content.FindName("SunshineUrl").Text
+                SunshineUser            = $window.Content.FindName("SunshineUser").Text
+                SunshinePass            = $window.Content.FindName("SunshinePass").Password
+                IgnoreCertificateErrors = $window.Content.FindName("IgnoreCertErrors").IsChecked
+                SyncOnStartup           = $window.Content.FindName("SyncOnStartup").IsChecked
             }
+            Set-PluginConfig -Config $newConfig
+            $window.Close()
         })
-    
 
-    # Attach a click event handler
-    $button = $window.Content.FindName("OKButton")
-    $button.Add_Click({
-            if ($button.Content -eq "Dismiss") {
-                $window.Close()
-            }
-            else {
-                $appsPath = $inputField.Text
-                $appsPath = $appsPath -replace '"', ''
-                $shortcutsCreatedCount = DoWork($appsPath)
-                $button.Content = "Dismiss"
-
-                $finishedMessage = $window.Content.FindName("FinishedMessage")
-                $finishedMessage.Text = ("Created {0} Sunshine app shortcuts" -f $shortcutsCreatedCount)
-                $finishedMessage.Visibility = "Visible"
-            }
+    $window.Content.FindName("CancelButton").Add_Click({
+            $window.Close()
         })
-    
-    # Set owner if you need to create modal dialog window
+
     $window.Owner = $PlayniteApi.Dialogs.GetCurrentAppWindow()
     $window.WindowStartupLocation = "CenterOwner"
-    
-    # Use Show or ShowDialog to show the window
     $window.ShowDialog()
+}
+
+function Invoke-SunshineRequest {
+    param(
+        [string]$Method,
+        [string]$Endpoint,
+        [object]$Body = $null
+    )
+
+    $config = Get-PluginConfig
+    $baseUri = $config.SunshineUrl.TrimEnd('/')
+    $uri = "$baseUri$Endpoint"
+
+    $headers = @{}
+    if (![string]::IsNullOrEmpty($config.SunshineUser) -or ![string]::IsNullOrEmpty($config.SunshinePass)) {
+        $auth = [Convert]::ToBase64String([Text.Encoding]::ASCII.GetBytes(("{0}:{1}" -f $config.SunshineUser, $config.SunshinePass)))
+        $headers.Add("Authorization", "Basic $auth")
+    }
+
+    $params = @{
+        Uri         = $uri
+        Method      = $Method
+        Headers     = $headers
+        ContentType = "application/json"
+    }
+
+    if ($Body) {
+        $params.Body = $Body | ConvertTo-Json -Depth 10
+    }
+
+    if ($config.IgnoreCertificateErrors) {
+        $params.SkipCertificateCheck = $true
+    }
+
+    try {
+        $response = Invoke-RestMethod @params
+        return $response
+    }
+    catch {
+        $__logger.Error("Sunshine API Error: $_")
+        throw $_
+    }
+}
+
+function Get-SunshineApps {
+    return Invoke-SunshineRequest -Method "GET" -Endpoint "/api/apps"
+}
+
+function Add-SunshineApp {
+    param($App)
+    return Invoke-SunshineRequest -Method "POST" -Endpoint "/api/apps" -Body $App
+}
+
+function Remove-SunshineApp {
+    param($Index)
+    return Invoke-SunshineRequest -Method "DELETE" -Endpoint "/api/apps/$Index"
+}
+
+function OnApplicationStarted {
+    $config = Get-PluginConfig
+    if (-not $config.SyncOnStartup) {
+        return
+    }
+
+    $installedGames = $PlayniteApi.Database.Games | Where-Object { $_.IsInstalled }
+    # Convert to List for Sync-Games
+    $gamesList = New-Object System.Collections.Generic.List[Playnite.SDK.Models.Game]
+    $gamesList.AddRange($installedGames)
+    
+    $count = Sync-Games -GamesToSync $gamesList -RemoveMissing $true
+    $__logger.Info("Sunshine Export: Synced $count games on startup.")
+}
+
+function SunshineExport {
+    param(
+        $scriptMainMenuItemActionArgs
+    )
+
+    $shortcutsCreatedCount = Sync-Games -GamesToSync $PlayniteApi.MainView.SelectedGames -RemoveMissing $false
+    $PlayniteApi.Dialogs.ShowMessage("Exported $shortcutsCreatedCount games to Sunshine.", "Sunshine Export")
 }
 
 function GetGameIdFromCmd([string]$cmd) {
@@ -138,7 +200,12 @@ function GetGameIdFromCmd([string]$cmd) {
     }
 }
 
-function DoWork([string]$appsPath) {
+function Sync-Games {
+    param(
+        [System.Collections.Generic.List[Playnite.SDK.Models.Game]]$GamesToSync,
+        [bool]$RemoveMissing = $false
+    )
+
     # Load assemblies
     Add-Type -AssemblyName System.Drawing
     $imageFormat = "System.Drawing.Imaging.ImageFormat" -as [type]
@@ -150,44 +217,52 @@ function DoWork([string]$appsPath) {
         New-Item -ItemType Container -Path $appAssetsPath -Force
     }
 
-    # Set creation counter
     $shortcutsCreatedCount = 0
+    
+    try {
+        $sunshineAppsResponse = Get-SunshineApps
+        $sunshineApps = $sunshineAppsResponse.apps
+    }
+    catch {
+        $PlayniteApi.Dialogs.ShowErrorMessage("Failed to connect to Sunshine. Please check your configuration.", "Sunshine Export Error")
+        return 0
+    }
 
-    $json = ConvertFrom-Json (Get-Content $appsPath -Raw)
+    # Create a hashset of Game IDs to sync for O(1) lookup
+    $gamesToSyncIds = New-Object System.Collections.Generic.HashSet[string]
+    foreach ($game in $GamesToSync) {
+        $gamesToSyncIds.Add($game.Id.ToString()) | Out-Null
+    }
 
-    foreach ($game in $PlayniteApi.MainView.SelectedGames) {
-        $gameLaunchCmd = "`"$playniteExecutablePath`" --start $($game.id)"
+    # 1. Add/Update Games
+    foreach ($game in $GamesToSync) {
+        $gameLaunchCmd = "`"$playniteExecutablePath`" --start $($game.Id)"
 
         # Set cover path and create blank file
-        $sunshineGameCoverPath = [System.IO.Path]::Combine($appAssetsPath, $game.id, "box-art.png")
+        $sunshineGameCoverPath = [System.IO.Path]::Combine($appAssetsPath, $game.Id, "box-art.png")
         if (!(Test-Path $sunshineGameCoverPath -PathType Container)) {
             New-Item -ItemType File -Path $sunshineGameCoverPath -Force | Out-Null
         }
 
         if ($null -ne $game.CoverImage) {
-
             $sourceCover = $PlayniteApi.Database.GetFullFilePath($game.CoverImage)
             if (($game.CoverImage -notmatch "^http") -and (Test-Path $sourceCover -PathType Leaf)) {
-
                 if ([System.IO.Path]::GetExtension($game.CoverImage) -eq ".png") {
                     Copy-Item $sourceCover $sunshineGameCoverPath -Force
                 }
                 else {
                     # Convert cover image to compatible PNG image format
                     try {
-                        # Create a BitmapImage and load the JPG image
                         $bitmap = New-Object System.Windows.Media.Imaging.BitmapImage
                         $bitmap.BeginInit()
                         $bitmap.UriSource = New-Object System.Uri($sourceCover, [System.UriKind]::Absolute)
                         $bitmap.CacheOption = [System.Windows.Media.Imaging.BitmapCacheOption]::OnLoad
                         $bitmap.EndInit()
                     
-                        # Create a PngBitmapEncoder and add the BitmapFrame
                         $encoder = New-Object System.Windows.Media.Imaging.PngBitmapEncoder
                         $frame = [System.Windows.Media.Imaging.BitmapFrame]::Create($bitmap)
                         $encoder.Frames.Add($frame)
                     
-                        # Save the PNG image
                         $fileStream = New-Object System.IO.FileStream($sunshineGameCoverPath, [System.IO.FileMode]::Create)
                         $encoder.Save($fileStream)
                         $fileStream.Close()
@@ -196,74 +271,73 @@ function DoWork([string]$appsPath) {
                         if ($null -ne $bitmap) { $bitmap = $null }
                         if ($null -ne $fileStream) { $fileStream.Close() }
                         $errorMessage = $_.Exception.Message
-                        $__logger.Info("Error converting cover image of `"$($game.name)`". Error: $errorMessage")
+                        $__logger.Info("Error converting cover image of `"$($game.Name)`". Error: $errorMessage")
                     }
-                }
-
-                $ids = @()
-                foreach ($app in $json.apps) {
-                    if ($app.id) {
-                        $ids += $app.id
-                    }
-                }
-
-                $id = Get-Random
-                while ($ids.Contains($id.ToString())) {
-                    $id = Get-Random
-                }
-
-                $newApp = New-Object -TypeName psobject
-                Add-Member -InputObject $newApp -MemberType NoteProperty -Name "name" -Value $game.name
-                Add-Member -InputObject $newApp -MemberType NoteProperty -Name "detached" -Value @($gameLaunchCmd)
-                Add-Member -InputObject $newApp -MemberType NoteProperty -Name "image-path" -Value $sunshineGameCoverPath
-                Add-Member -InputObject $newApp -MemberType NoteProperty -Name "id" -Value $id.ToString()
-
-                $json.apps = $json.apps | ForEach-Object {
-                    if ($_.detached) {
-                        $gameId = GetGameIdFromCmd($_.detached[0])
-                        if ($gameId -eq $game.id) {
-                            $newApp
-                        }
-                        else {
-                            $_
-                        }
-                    }
-                    else {
-                        $_
-                    }
-                }
-
-                if (!($json.apps | Where-Object { 
-                            if ($_.detached) {
-                                $gameId = GetGameIdFromCmd($_.detached[0])
-                                return $gameId -eq $game.id
-                            }
-                            else {
-                                return $false
-                            }
-                        })) {
-                    [object[]]$json.apps += $newApp
                 }
             }
         }
 
-        $shortcutsCreatedCount++
+        # Check if app already exists in Sunshine
+        $existingAppIndex = -1
+        for ($i = 0; $i -lt $sunshineApps.Count; $i++) {
+            $app = $sunshineApps[$i]
+            if ($app.detached -and $app.detached.Length -gt 0) {
+                $existingGameId = GetGameIdFromCmd($app.detached[0])
+                if ($existingGameId -eq $game.Id.ToString()) {
+                    $existingAppIndex = $i
+                    break
+                }
+            }
+        }
+
+        $newApp = @{
+            name         = $game.Name
+            detached     = @($gameLaunchCmd)
+            "image-path" = $sunshineGameCoverPath
+            index        = $existingAppIndex
+        }
+
+        try {
+            Add-SunshineApp -App $newApp
+            $shortcutsCreatedCount++
+        }
+        catch {
+            $__logger.Error("Failed to add/update app for game $($game.Name): $_")
+        }
     }
 
-    $jsonObj = ConvertTo-Json $json -Depth 100
-    # Write this using utf8-noBOM, which depending on PS version, is not supported.
-    # so as a workaround, we'll use WriteAllLines which defaults to utf8-noBOM
-    [System.IO.File]::WriteAllLines("$env:TEMP\apps.json", $jsonObj)
-
-
-    $result = [System.Windows.Forms.MessageBox]::Show("You will be prompted for administrator rights, as Sunshine now requires administrator rights in order to modify the apps.json file.", "Administrator Required", [System.Windows.Forms.MessageBoxButtons]::OKCancel, [System.Windows.Forms.MessageBoxIcon]::Information)
-    if ($result -eq [System.Windows.Forms.DialogResult]::Cancel) {
-        return 0
+    # 2. Remove Missing Games (if requested)
+    if ($RemoveMissing) {
+        # We need to iterate backwards because removing items changes indices?
+        # Wait, Sunshine API uses index. If we remove item at index 0, does item at index 1 become 0?
+        # Most likely yes. So we should verify this or iterate backwards.
+        # However, the API documentation says: "Delete an application." DELETE /api/apps/{index}
+        # It's safer to iterate backwards.
+        
+        # Also, we need to be careful: if we remove an app, the indices of subsequent apps shift.
+        # So we should probably re-fetch the list or be very careful.
+        # Re-fetching is safer but slower.
+        # Iterating backwards is usually safe for removal by index.
+        
+        for ($i = $sunshineApps.Count - 1; $i -ge 0; $i--) {
+            $app = $sunshineApps[$i]
+            if ($app.detached -and $app.detached.Length -gt 0) {
+                $existingGameId = GetGameIdFromCmd($app.detached[0])
+                if (![string]::IsNullOrEmpty($existingGameId)) {
+                    # It's a Playnite exported app. Check if it should be synced.
+                    if (-not $gamesToSyncIds.Contains($existingGameId)) {
+                        try {
+                            Remove-SunshineApp -Index $i
+                            $__logger.Info("Removed Sunshine app for game ID: $existingGameId")
+                        }
+                        catch {
+                            $__logger.Error("Failed to remove Sunshine app at index $i: $_")
+                        }
+                    }
+                }
+            }
+        }
     }
-    else {
-        Start-Process powershell.exe  -Verb RunAs -ArgumentList "-ExecutionPolicy Bypass -Command `"Copy-Item -Path $env:TEMP\apps.json -Destination '$appsPath'`"" -WindowStyle Hidden
-    }
-
 
     return $shortcutsCreatedCount
 }


### PR DESCRIPTION
Loved the tool, but I was really looking for a more automated solution that didn't involve having to restart Sunshine. I rewrote a bunch of it and figured I'd give it back if you wanted it.

With this PR I've updated the extension to hook into 3 Playnite events:

OnApplicationStarted - allows for syncing all installed Playnite games on startup

OnGameInstalled
OnGameUninstalled
- Which allow for real time sync of games as they are installed and uninstalled

Both of these are opt-in - meaning you can just not turn them on, and instead leverage the existing flow of manually selecting and exporting.

In all cases, the script updates Sunshine via API rather than a config file, so even if you stick to manual syncs, there's no need to restart Sunshine anymore. 

I understand this is a pretty fundamental change to your extension - I have no issues if you don't want to accept this, just let me know and I'll sever the fork.
